### PR TITLE
Add GitHub action that triggers AWS create_os_documents lambda function every time road-choice-make-model-part-filter-options file is published

### DIFF
--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -14,7 +14,7 @@ jobs:
         echo "Org: ${{ github.event.client_payload.org }}"
         echo "Path: ${{ github.event.client_payload.path }}"
   notify-connector:
-    if: (github.event.client_payload.status == 200 || github.event.client_payload.status == 204) && endsWith(github.event.client_payload.path, '.json')
+    if: (github.event.client_payload.status == 200 || github.event.client_payload.status == 204) && contains(github.event.client_payload.path, 'road-choice-make-model-part-filter-options')
     runs-on: ubuntu-latest
     steps:
     - name: Notify create_os_documents endpoint

--- a/.github/workflows/publish-notifier.yaml
+++ b/.github/workflows/publish-notifier.yaml
@@ -1,0 +1,30 @@
+name: RoadChoice Search Connector - Create_os_documents
+
+on:
+  repository_dispatch:
+    types:
+      - resource-published
+jobs:
+  check-event-status:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo "Status: ${{ github.event.client_payload.status }}"
+        echo "Site: ${{ github.event.client_payload.site }}"
+        echo "Org: ${{ github.event.client_payload.org }}"
+        echo "Path: ${{ github.event.client_payload.path }}"
+  notify-connector:
+    if: (github.event.client_payload.status == 200 || github.event.client_payload.status == 204) && endsWith(github.event.client_payload.path, '.json')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify create_os_documents endpoint
+      run: |
+        sleep 120s
+        PAGE_PATH=$(echo "${{ github.event.client_payload.path }}"
+        WEBSITE_NAME="${{ github.event.client_payload.site }}"
+        URI=$(echo "${{ vars.ROADCHOICE_CONNECTOR_DOMAIN }}/$WEBSITE_NAME")
+        BODY='"'$PAGE_PATH'"'
+        BODY="$(echo "$BODY" | jq -c)"
+        response=$(curl -s -H "x-api-key: ${{ secrets.ROADCHOICE_API_KEY }}" -X POST "$URI" -d "$BODY")
+        echo "response: $response"
+      shell: bash


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

FR: [Ingestion] - Synchronize parts information with OpenSearch index (6 of 6)
[#45](https://github.com/aemsites/vg-roadchoice-com/issues/45)

## Test URLs:
- No test URLs. GitHub action must be tested once it is merged to the main branch.
