### PR TITLE
Adapt placeholder's multi-language blocks (1 of 2) #101

### DIFF
--- a/blocks/pagination/pagination.js
+++ b/blocks/pagination/pagination.js
@@ -3,12 +3,12 @@ import { getAndApplySearchResults } from '../search/search.js';
 
 const blockName = 'pagination';
 const buttonTextContent = getTextLabel('pagination_button');
-const partWord = getTextLabel('part');
+const partsWord = getTextLabel('parts');
 
 export default async function decorate(block) {
   const paginationSection = createElement('div', { classes: `${blockName}-section` });
   const paginationTitle = createElement('h2', { classes: 'title' });
-  paginationTitle.textContent = `${partWord}s`;
+  paginationTitle.textContent = `${partsWord}`;
   const showingSection = createElement('div', { classes: 'showing-section' });
   const topResultsElement = createElement('p', { classes: 'top-results-text' });
   showingSection.append(topResultsElement);

--- a/blocks/pagination/pagination.js
+++ b/blocks/pagination/pagination.js
@@ -2,14 +2,13 @@ import { getTextLabel, createElement } from '../../scripts/common.js';
 import { getAndApplySearchResults } from '../search/search.js';
 
 const blockName = 'pagination';
-const partNumberText = getTextLabel('part_number');
 const buttonTextContent = getTextLabel('pagination_button');
-const firstWord = partNumberText.split(' ')[0];
+const partWord = getTextLabel('part');
 
 export default async function decorate(block) {
   const paginationSection = createElement('div', { classes: `${blockName}-section` });
   const paginationTitle = createElement('h2', { classes: 'title' });
-  paginationTitle.textContent = `${firstWord}s`;
+  paginationTitle.textContent = `${partWord}s`;
   const showingSection = createElement('div', { classes: 'showing-section' });
   const topResultsElement = createElement('p', { classes: 'top-results-text' });
   showingSection.append(topResultsElement);

--- a/constants.json
+++ b/constants.json
@@ -68,7 +68,7 @@
     "data": [
       {
         "name": "SEARCH_URL_DEV",
-        "value": "https://search-api-qa-eds.aws.43636.vnonprod.com/search"
+        "value": "https://kb3ko4nzt2.execute-api.eu-west-1.amazonaws.com/prod/search"
       },
       {
         "name": "CROSS_REFERENCE_QUERY_NAME",

--- a/placeholder.json
+++ b/placeholder.json
@@ -44,8 +44,8 @@
       "Text": "Part Number"
     },
     {
-      "Key": "part",
-      "Text": "Part"
+      "Key": "parts",
+      "Text": "Parts"
     },
     {
       "Key": "pagination_text",

--- a/placeholder.json
+++ b/placeholder.json
@@ -44,6 +44,10 @@
       "Text": "Part Number"
     },
     {
+      "Key": "part",
+      "Text": "Part"
+    },
+    {
       "Key": "pagination_text",
       "Text": "Showing top [$] results"
     },


### PR DESCRIPTION
## Fix

This fix gathers the proper word, `parts,` from the `placeholder.json` file, allowing the word to be translated into other languages.

### Note

The search URL in the local `constants.json` file was incorrect. for all the environments, the prod URL needs to be updated to work in a local environment

#

Fix #101

## Test URLs:
- Before: https://main--vg-roadchoice-com--volvogroup.aem.page/search/?q=bumpers&st=parts&make=null&model=null&offset=0
- After: https://101-placeholders-multi-language--vg-roadchoice-com--volvogroup.aem.page/search/?q=bumpers&st=parts&make=null&model=null&offset=0

### Other markets:

#### Canada:
- Before: https://main--roadchoice-ca--volvogroup.aem.page/fr-ca/search/?q=bumpers&st=parts&make=null&model=null&offset=0
- After: https://101-placeholders-multi-language--roadchoice-ca--volvogroup.aem.page/fr-ca/search/?q=bumpers&st=parts&make=null&model=null&offset=0

#### Mexico:
- Before: https://main--roadchoice-mx--volvogroup.aem.page/search/?q=bumpers&st=parts&make=null&model=null&offset=0
- After: https://101-placeholders-multi-language--roadchoice-mx--volvogroup.aem.page/search/?q=bumpers&st=parts&make=null&model=null&offset=0
