### PR TITLE
FR: Update code to read placeholder.json file #133

### DIFF
--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -219,7 +219,7 @@ const updatePagination = (resultsSection, targetOffset, resultsLength) => {
 
 const showNoResultsMessage = (query, searchResultsSection) => {
   const titleElement = searchResultsSection?.querySelector('.title');
-  const titleText = getTextLabel('no_results_title').replace('[$]', query ? `${query}` : '');
+  const titleText = getTextLabel('no_results_title').replace('[$]', query ? `"${query}"` : '');
   if (titleElement) titleElement.innerText = titleText;
   const fragment = document.createRange().createContextualFragment(noResultsTemplate);
   searchResultsSection?.classList.add('no-results');

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -170,7 +170,7 @@ const getSearchTitleText = ({ searchType, query, make, model }) => {
   return getTextLabel(`SEARCH_RESULT:${searchType}_title`)
     .replace('[$1]', make ? `"${make}" ` : '')
     .replace('[$2]', model ? `"${model}" ` : '')
-    .replace('[$q]', `"${query}"`);
+    .replace('[$q]', query ? `"${query}"` : '');
 };
 
 const updateSearchResults = (results, searchType, query, make, model, resultsSection, resultsList, targetOffset) => {

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -154,6 +154,25 @@ const showLoader = (resultsSection) => {
   return loadingElement;
 };
 
+/**
+ * returns the search title text based on the search type
+ * @description __cross-reference template text:__ _Search Results for Cross-Reference: [$q]_;
+ * @example 'Search Results for Cross-Reference: "123456"';
+ * @description part number template text: _Search Results for "[$1]" "[$2]" "[$q]" parts_;
+ * @example 'Search Results for "[make]" "[model]" "[part number or description]" parts';
+ * @param {string} searchType - the search type
+ * @param {string} query - the search query
+ * @param {string} make - the make of the product
+ * @param {string} model - the model of the product
+ * @returns {string} - the search title text
+ */
+const getSearchTitleText = ({ searchType, query, make, model }) => {
+  return getTextLabel(`SEARCH_RESULT:${searchType}_title`)
+    .replace('[$1]', make ? `"${make}" ` : '')
+    .replace('[$2]', model ? `"${model}" ` : '')
+    .replace('[$q]', `"${query}"`);
+};
+
 const updateSearchResults = (results, searchType, query, make, model, resultsSection, resultsList, targetOffset) => {
   const searchResultsSection = document.querySelector('.search-results-section');
   const titleElement = searchResultsSection?.querySelector('.title');
@@ -163,9 +182,12 @@ const updateSearchResults = (results, searchType, query, make, model, resultsSec
       const liElement = productCard(result, searchType);
       resultsList?.appendChild(liElement);
     });
-    const titleContent = getTextLabel('search_results_title');
-    const type = searchType === 'cross' ? 'cross-reference' : 'parts';
-    const titleText = `${titleContent} ${searchType === 'cross' ? `${type}: "${query}"` : `${make || ''} ${model || ''} ${query} ${type}`}`;
+    const titleText = getSearchTitleText({
+      searchType,
+      query,
+      make,
+      model,
+    });
     if (titleElement) titleElement.textContent = titleText;
 
     updatePagination(resultsSection, targetOffset, results.length);

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -219,7 +219,7 @@ const updatePagination = (resultsSection, targetOffset, resultsLength) => {
 
 const showNoResultsMessage = (query, searchResultsSection) => {
   const titleElement = searchResultsSection?.querySelector('.title');
-  const titleText = getTextLabel('no_results_title').replace('[$]', `${query}`);
+  const titleText = getTextLabel('no_results_title').replace('[$]', query ? `${query}` : '');
   if (titleElement) titleElement.innerText = titleText;
   const fragment = document.createRange().createContextualFragment(noResultsTemplate);
   searchResultsSection?.classList.add('no-results');

--- a/placeholder.json
+++ b/placeholder.json
@@ -36,8 +36,12 @@
       "Text": "Part Number/Description"
     },
     {
-      "Key": "search_results_title",
-      "Text": "Search Results for"
+      "Key": "SEARCH_RESULT:cross_title",
+      "Text": "Search Results for Cross-Reference: [$q]"
+    },
+    {
+      "Key": "SEARCH_RESULT:parts_title",
+      "Text": "Search Results for [$1][$2][$q] parts"
     },
     {
       "Key": "part_number",


### PR DESCRIPTION
# Update

set the search results title text dynamic to be set in the `placeholder.json` file

Fix #133

Search Path:

--- Cross-reference search ---
search/?q=900014bt&st=cross&offset=0

--- Part number search ---
search/?q=rad37160p&st=parts&make=Ford&model=A9500&offset=0

## Test URLs:

- Before: https://main--vg-roadchoice-com--volvogroup.aem.page/
- After: https://133-result-title-multi-language--vg-roadchoice-com--volvogroup.aem.page/

### Other markets:

#### Canada:
- Before: https://main--roadchoice-ca--volvogroup.aem.page/fr-ca/
- After: https://133-result-title-multi-language--roadchoice-ca--volvogroup.aem.page/fr-ca/
(English Canada is the same as US, but it can be tested anyway)

#### Mexico:
- Before: https://main--roadchoice-mx--volvogroup.aem.page/
- After: https://133-result-title-multi-language--roadchoice-mx--volvogroup.aem.page/
