### PR TITLE
FR: Add text to the product category pages #144

### DIFF
--- a/templates/part-category/part-category.css
+++ b/templates/part-category/part-category.css
@@ -2,6 +2,15 @@
   color: var(--primary-red);
 }
 
+.part-category .part-category-subtitle {
+  margin-bottom: 15px;
+}
+
+
+.part-category .part-category-subtitle a {
+  margin-left: 5px;
+}
+
 @media (min-width: 1200px) {
   .part-category {
     display: grid;

--- a/templates/part-category/part-category.js
+++ b/templates/part-category/part-category.js
@@ -123,8 +123,7 @@ const updateTitleWithSubcategory = (title, category, categoryData) => {
  */
 const getSubtitleData = async (cat) => {
   try {
-    // todo change this to make it dynamic
-    const url = '/part-category/subcategory-text.json';
+    const url = getLocaleContextedUrl('/part-category/subcategory-text.json');
     const products = await getJsonFromUrl(url);
     const { data } = products;
     const result = data?.filter((obj) => obj.subcategory === cat);

--- a/templates/part-category/part-category.js
+++ b/templates/part-category/part-category.js
@@ -127,6 +127,7 @@ const getSubtitleData = async (cat) => {
     const products = await getJsonFromUrl(url);
     const { data } = products;
     const result = data?.filter((obj) => obj.subcategory === cat);
+
     return result[0];
   } catch (err) {
     console.log('%cError fetching subcategories', err);
@@ -147,19 +148,23 @@ export default async function decorate(doc) {
   titleWrapper.appendChild(title);
 
   const subtitleObject = await getSubtitleData(category);
-  const { text, linkText, linkUrl } = subtitleObject;
-
-  const subtitle = createElement('p', { classes: 'part-category-subtitle' });
-  subtitle.textContent = text;
-
-  const subtitleLink = createElement('a', { props: { href: linkUrl } });
-  subtitleLink.textContent = linkText;
-  checkLinkProps([subtitleLink]);
-  if (subtitleLink) {
-    subtitle.insertAdjacentElement('beforeend', subtitleLink);
-  }
-  if (subtitle) {
-    titleWrapper.appendChild(subtitle);
+  if (subtitleObject) {
+    const { text, linkText, linkUrl } = subtitleObject;
+    if (text.length > 0) {
+      const subtitle = createElement('p', { classes: 'part-category-subtitle' });
+      subtitle.textContent = text;
+      if (linkText.length > 0) {
+        const subtitleLink = createElement('a', { props: { href: linkUrl } });
+        subtitleLink.textContent = linkText;
+        checkLinkProps([subtitleLink]);
+        if (subtitleLink) {
+          subtitle.insertAdjacentElement('beforeend', subtitleLink);
+        }
+      }
+      if (subtitle) {
+        titleWrapper.appendChild(subtitle);
+      }
+    }
   }
 
   const section = [...main.children].filter((child) => !['breadcrumb-container', 'search-container'].some((el) => child.classList.contains(el)))[0];

--- a/templates/part-category/part-category.js
+++ b/templates/part-category/part-category.js
@@ -1,4 +1,4 @@
-import { createElement, getLongJSONData, DEFAULT_LIMIT, getLocaleContextedUrl, getJsonFromUrl, checkLinkProps } from '../../scripts/common.js';
+import { createElement, getLongJSONData, DEFAULT_LIMIT, getLocaleContextedUrl, getJsonFromUrl } from '../../scripts/common.js';
 import { decorateLinks } from '../../scripts/scripts.js';
 
 const url = new URL(window.location.href);
@@ -163,8 +163,8 @@ export default async function decorate(doc) {
         ${linkText?.length > 0 ? `<a href='${linkUrl}'>${linkText}</a>` : ''}
       </p>
     `);
-    decorateLinks(titleWrapper);
     titleWrapper.appendChild(subtitle);
+    decorateLinks(titleWrapper);
   }
 
   const section = [...main.children].filter((child) => !['breadcrumb-container', 'search-container'].some((el) => child.classList.contains(el)))[0];

--- a/templates/part-category/part-category.js
+++ b/templates/part-category/part-category.js
@@ -119,7 +119,7 @@ const updateTitleWithSubcategory = (title, category, categoryData) => {
 
 /**
  * Fetches and formats the subcategory data to build the subtitle.
- * @returns {Object}
+ * @returns {Object} The subcategory data as single object.
  * @throws {Error} If the subcategory data is not found.
  */
 const getSubtitleData = async (cat) => {


### PR DESCRIPTION
A spreadsheet with the subcategory names and its corresponding text and link has been created in the same `/part-category` folder where this template lives. This spreadsheet exists in all market sites

All the possible variations for this subtitle have been created and listed below:

-  `/part-category/?category=coolant-accesories` -> all values have been added, text, link and subcategory
-  `/part-category/?category=def`-> only text for this subcategory, no link
-  `/part-category/?category=batteries` -> no text or link has been created but the subcategory is listed to check it wont fail if content is missing. Subtitle should not appear at all
-  `/part-category/?category=fan-clutches` -> no subcategory is listed with this name in order to check that it still does not fail if value is missing.

Fix #144

## Test URLs:
- Before: https://main--vg-roadchoice-com--volvogroup.aem.page/part-category/?category=coolant-accessories
- After: https://144-subcategory-text--vg-roadchoice-com--volvogroup.aem.page/part-category/?category=coolant-accessories

### Other markets:

#### Canada English:
- Before: https://main--roadchoice-ca--volvogroup.aem.page/en-ca/part-category/?category=coolant-accessories
- After: https://144-subcategory-text--roadchoice-ca--volvogroup.aem.page/en-ca/part-category/?category=coolant-accessories

#### Canada French:
- Before: https://main--roadchoice-ca--volvogroup.aem.page/fr-ca/part-category/?category=coolant-accessories
- After: https://144-subcategory-text--roadchoice-ca--volvogroup.aem.page/fr-ca/part-category/?category=coolant-accessories

#### Mexico:
- Before: https://main--roadchoice-mx--volvogroup.aem.page/part-category/?category=coolant-accessories
- After: https://144-subcategory-text--roadchoice-mx--volvogroup.aem.page/part-category/?category=coolant-accessories
