### PR TITLE
NFR: Update the breadcrumbs to show a maximum amount to prevent scrolling #22

### DIFF
--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -1,5 +1,6 @@
 :root {
   --breadcrumb-hover: #15909c;
+  --ellipse-width: 100%;
 }
 
 .section.breadcrumb-container {
@@ -43,6 +44,17 @@
 .breadcrumb-list li a {
   display: inline-flex;
   width: max-content;
+}
+
+.breadcrumb-item:has(.active-link) {
+  width: var(--ellipse-width);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.breadcrumb-item .active-link {
+  display: inline;
 }
 
 .breadcrumb-list .breadcrumb-item:nth-child(2) {

--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -37,7 +37,6 @@
   color: var(--secondary-gray-4);
   text-decoration: none;
   font-size: var(--body-font-size-s);
-  margin: 0 3px 15px 0;
   text-transform: capitalize;
 }
 
@@ -46,14 +45,19 @@
   width: max-content;
 }
 
-.breadcrumb-item:has(.active-link) {
+.breadcrumb a:hover {
+  color: var(--breadcrumb-hover);
+}
+
+.breadcrumb-list .breadcrumb-item:last-of-type {
   width: var(--ellipse-width);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 0 15px 0 0;
 }
 
-.breadcrumb-item .active-link {
+.breadcrumb-list .breadcrumb-item:last-of-type a {
   display: inline;
 }
 
@@ -61,47 +65,21 @@
   display: none;
 }
 
-.breadcrumb a:hover {
-  color: var(--breadcrumb-hover);
-}
-
-.breadcrumb a::after {
+.breadcrumb .breadcrumb-item:not(:last-of-type) a::after {
   content: '/';
   margin: 0 5px;
   color: var(--secondary-gray-4);
 }
 
-.breadcrumb .active-link::after {
-  content: unset;
-}
-
 @media (min-width: 768px) {
-  .breadcrumb .active-link::after {
-    content: '/';
-  }
-
-  .breadcrumb-item-2 .active-link::after {
-    content: unset;
-  }
-
   .breadcrumb-list .breadcrumb-item:nth-child(2) {
     display: block;
   }
 }
 
 @media (min-width: 992px) {
-  .breadcrumb-content {
-    padding: 10px unset;
-  }
-
   .breadcrumb-list {
     max-width: 1270px;
-    padding: 10px unset;
-  }
-}
-
-@media (min-width: 1200px) {
-  .breadcrumb-list li:last-of-type a {
-    width: unset;
+    padding: 10px 0;
   }
 }

--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -80,6 +80,6 @@
 @media (min-width: 992px) {
   .breadcrumb-list {
     max-width: 1270px;
-    padding: 10px 0;
+    padding: 20px 0;
   }
 }

--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -1,6 +1,5 @@
 :root {
   --breadcrumb-hover: #15909c;
-  --ellipse-width: 100%;
 }
 
 .section.breadcrumb-container {
@@ -50,7 +49,7 @@
 }
 
 .breadcrumb-list .breadcrumb-item:last-of-type {
-  width: var(--ellipse-width);
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
# Fixed

In this update, the breadcrumb adds an ellipsis if the text is too long and keeps it as a single line. 
If the text is not too long, but is long in smaller viewports, then it also adds the ellipsis.
On another kind of page, like the sub-category page (the 3rd CA link), it only adds the ellipsis if the viewport is small enough

#
Fix #22 

## Test URLs:
- Before: https://main--vg-roadchoice-com--volvogroup.aem.page/blog/first-dedicated-road-choice-parts-retail-store-opens-at-ballard-truck-center-in-massachusetts
- After: https://22-breadcrumbs-elipsis--vg-roadchoice-com--volvogroup.aem.page/blog/first-dedicated-road-choice-parts-retail-store-opens-at-ballard-truck-center-in-massachusetts

### Other markets:
#### Canada:
- Before: https://main--roadchoice-ca--volvogroup.aem.page/fr-ca/blog/the-case-for-rebuilt-fan-cluthches-why-buy-new-when-reman-will-do
- After: https://22-breadcrumbs-elipsis--roadchoice-ca--volvogroup.aem.page/fr-ca/blog/the-case-for-rebuilt-fan-cluthches-why-buy-new-when-reman-will-do
- Before: https://main--roadchoice-ca--volvogroup.aem.page/fr-ca/blog/five-tips-for-better-battery-performance
- After: https://22-breadcrumbs-elipsis--roadchoice-ca--volvogroup.aem.page/fr-ca/blog/five-tips-for-better-battery-performance
- Before: https://main--roadchoice-ca--volvogroup.aem.page/fr-ca/part-category/?category=grille-guards
- After: https://22-breadcrumbs-elipsis--roadchoice-ca--volvogroup.aem.page/fr-ca/part-category/?category=grille-guards

#### Mexico:
- Before: https://main--roadchoice-mx--volvogroup.aem.page/blog/first-dedicated-road-choice-parts-retail-store-opens-at-ballard-truck-center-in-massachusetts
- After: https://22-breadcrumbs-elipsis--roadchoice-mx--volvogroup.aem.page/blog/first-dedicated-road-choice-parts-retail-store-opens-at-ballard-truck-center-in-massachusetts
