### PR TITLE
Bug: Fuzzy search is not working on Canada site #221

### DIFF
--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -320,11 +320,10 @@ function addFormListener(form) {
     const url = new URL(window.location.href);
     url.pathname = getLocaleContextedUrl('/search/');
     const fuzzyTerm = url.searchParams.get('fuzzyTerm');
-    const fuzzyness = url.searchParams.get('fuzzyness');
     const makeFilterValue = getMakeFilterValue(items);
     const modelFilterValue = getFieldValue(`${blockName}__model-filter__select`, items);
 
-    if (!isCrossRefActive && !wrapper?.children?.length && !fuzzyness) {
+    if (!isCrossRefActive && !wrapper?.children?.length) {
       url.search = `?fuzzyTerm=${value}&st=parts${makeFilterValue ? `&make=${makeFilterValue}` : ''}${modelFilterValue ? `&model=${modelFilterValue}` : ''}`;
     } else {
       const searchType = isCrossRefActive


### PR DESCRIPTION
## Fixes 

It removes the need to check if fuzziness is in the URL to re-enable the suggestion page again.

steps to test:
1st, swap the search type to `part number`.
2nd, type "_radiatorrr_" and click submit -> the URL should end like this: `search/?fuzzyTerm=radiatorrr&st=parts`.
3rd, swap again to `cross-reference`.
4th, type again "_radiatorrr_" and submit it -> the URL should end like this: `search/?q=radiatorrr&st=cross&offset=0&fuzzyness=true`.
5th, swap one more time to `part number`.
6th repeat 2nd step

If it works as expected, after step 6, in the test branch (not the main one), it should show the "Did you mean" page again.

#
Fix #221 

## Test URLs:
- Before: https://main--vg-roadchoice-com--volvogroup.aem.page/
- After: https://221-fuzzy-search-bug-ca--vg-roadchoice-com--volvogroup.aem.page/

### Other markets:

#### Canada:
- Before: https://main--roadchoice-ca--volvogroup.aem.page/en-ca/
- After: https://221-fuzzy-search-bug-ca--roadchoice-ca--volvogroup.aem.page/en-ca/

