### PR TITLE
FR: "Did you mean" feature for search input corrections #205

### DIFF
--- a/blocks/search/autosuggest-helper.js
+++ b/blocks/search/autosuggest-helper.js
@@ -108,7 +108,7 @@ export async function applyFuzzySearch(fuzzyTerm) {
     const noResultsTitleEl = createElement('h1', { classes: [`${blockName}__no-results-title`] });
     const noResultsTitleHtml = getTextLabel('no_results_title').replace(
       '[$]',
-      `<span class="${blockName}__no-results-term">"${fuzzyTerm || ''}"</span>`,
+      `<span class="${blockName}__no-results-term">${fuzzyTerm || ''}</span>`,
     );
     noResultsTitleEl.innerHTML = noResultsTitleHtml;
 

--- a/blocks/search/autosuggest-helper.js
+++ b/blocks/search/autosuggest-helper.js
@@ -105,12 +105,15 @@ export async function applyFuzzySearch(fuzzyTerm) {
     partBtn?.click();
 
     fuzzyWrapper.append(fuzzyText, list);
-    const h1 = createElement('h1', { classes: [`${blockName}__fuzzysearch-title`] });
-    const titleHTML = getTextLabel('no_results_title').replace('[$]', `<span class="${blockName}__fuzzysearch-term">${fuzzyTerm || ''}</span>`);
-    h1.innerHTML = titleHTML;
+    const noResultsTitleEl = createElement('h1', { classes: [`${blockName}__no-results-title`] });
+    const noResultsTitleHtml = getTextLabel('no_results_title').replace(
+      '[$]',
+      `<span class="${blockName}__no-results-term">"${fuzzyTerm || ''}"</span>`,
+    );
+    noResultsTitleEl.innerHTML = noResultsTitleHtml;
+
     if (searchResultsSection) {
-      searchResultsSection.innerHTML = '';
-      searchResultsSection.append(h1, fuzzyWrapper);
+      searchResultsSection.replaceChildren(noResultsTitleEl, fuzzyWrapper);
     }
   }
   return suggestions;

--- a/blocks/search/autosuggest-helper.js
+++ b/blocks/search/autosuggest-helper.js
@@ -105,7 +105,13 @@ export async function applyFuzzySearch(fuzzyTerm) {
     partBtn?.click();
 
     fuzzyWrapper.append(fuzzyText, list);
-    searchResultsSection?.prepend(fuzzyWrapper);
+    const h1 = createElement('h1', { classes: [`${blockName}__fuzzysearch-title`] });
+    const titleHTML = getTextLabel('no_results_title').replace('[$]', `<span class="${blockName}__fuzzysearch-term">"${fuzzyTerm || ''}"</span>`);
+    h1.innerHTML = titleHTML;
+    if (searchResultsSection) {
+      searchResultsSection.innerHTML = '';
+      searchResultsSection.append(h1, fuzzyWrapper);
+    }
   }
   return suggestions;
 }

--- a/blocks/search/autosuggest-helper.js
+++ b/blocks/search/autosuggest-helper.js
@@ -106,7 +106,7 @@ export async function applyFuzzySearch(fuzzyTerm) {
 
     fuzzyWrapper.append(fuzzyText, list);
     const h1 = createElement('h1', { classes: [`${blockName}__fuzzysearch-title`] });
-    const titleHTML = getTextLabel('no_results_title').replace('[$]', `<span class="${blockName}__fuzzysearch-term">"${fuzzyTerm || ''}"</span>`);
+    const titleHTML = getTextLabel('no_results_title').replace('[$]', `<span class="${blockName}__fuzzysearch-term">${fuzzyTerm || ''}</span>`);
     h1.innerHTML = titleHTML;
     if (searchResultsSection) {
       searchResultsSection.innerHTML = '';

--- a/blocks/search/search.css
+++ b/blocks/search/search.css
@@ -153,6 +153,7 @@
 
 .search__fuzzysearch-results-wrapper {
   display: flex;
+  justify-content: center;
   gap: 30px;
   padding-bottom: 30px;
 }
@@ -164,6 +165,20 @@
   color: var(--primary-red);
   font-weight: 700;
   cursor: pointer;
+}
+
+.search__fuzzysearch-title {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 25px;
+  font-size: 30px;
+  font-weight: 900;
+  line-height: 38px;
+  color: var(--primary-red);
+}
+
+.search__fuzzysearch-term {
+  text-transform: none;
 }
 
 @media (min-width: 360px) {

--- a/blocks/search/search.css
+++ b/blocks/search/search.css
@@ -167,7 +167,7 @@
   cursor: pointer;
 }
 
-.search__fuzzysearch-title {
+.search__no-results-title {
   text-align: center;
   margin-top: 0;
   margin-bottom: 25px;
@@ -177,7 +177,7 @@
   color: var(--primary-red);
 }
 
-.search__fuzzysearch-term {
+.search__no-results-term {
   text-transform: none;
 }
 

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -109,6 +109,7 @@ function addSearchByListeners(wrapper, form) {
 
     if (e.target.classList.contains(`${blockName}__cross-reference__btn`)) {
       document.querySelector(`.${blockName}__fuzzysearch-results-wrapper`)?.remove();
+      document.querySelector(`.${blockName}__fuzzysearch-title`)?.remove();
     }
   };
 }

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -109,7 +109,7 @@ function addSearchByListeners(wrapper, form) {
 
     if (e.target.classList.contains(`${blockName}__cross-reference__btn`)) {
       document.querySelector(`.${blockName}__fuzzysearch-results-wrapper`)?.remove();
-      document.querySelector(`.${blockName}__fuzzysearch-title`)?.remove();
+      document.querySelector(`.${blockName}__no-results-title`)?.remove();
     }
   };
 }


### PR DESCRIPTION
Fix #205

The text "SORRY, YOUR SEARCH FOR "{fuzzy term}" RETURNED NO RESULTS!" differs from the Figma design, but it is also used on the cross-reference no-results page and can be updated by the content team if necessary.

## Test URLs:
- Before: https://main--vg-roadchoice-com--volvogroup.aem.page/search/?fuzzyTerm=break&st=parts
- After: https://205-search-fuzzysearch--vg-roadchoice-com--volvogroup.aem.page/search/?fuzzyTerm=break&st=parts